### PR TITLE
[VI-88] Pin Prettier and secure local Node setup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     hooks:
       - id: prettier-markdown
         name: run prettier on markdown files
-        entry: npx prettier --write
+        entry: ./node_modules/.bin/prettier --write
         language: system
         types: [markdown]
         files: \.md$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     hooks:
       - id: prettier-markdown
         name: run prettier on markdown files
-        entry: ./node_modules/.bin/prettier --write
+        entry: npx --no-install prettier --write
         language: system
         types: [markdown]
         files: \.md$

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This works: `## My Text <a href="#my-text" id="my-text"></a>`
 
 MyST generates IDs based on the section text, so our IDs must match the generated ones. It's tedious, but necessary. Every time when we change a caption for some section - we need to update the corresponding ID
 
-We use prettier to ensure compatibility with Gitbook. You can install prettier in your local repository with the following command:
+We use prettier to ensure compatibility with Gitbook. Install the locked Node dependencies before running the local formatting hooks:
 
 ```bash
 npm ci --ignore-scripts

--- a/README.md
+++ b/README.md
@@ -39,5 +39,5 @@ MyST generates IDs based on the section text, so our IDs must match the generate
 We use prettier to ensure compatibility with Gitbook. You can install prettier in your local repository with the following command:
 
 ```bash
-npm install
+npm ci --ignore-scripts
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "devDependencies": {
-        "prettier": "^3.5.3"
+        "prettier": "3.5.3"
       }
     },
     "node_modules/prettier": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "devDependencies": {
-    "prettier": "^3.5.3"
+    "prettier": "3.5.3"
   }
 }


### PR DESCRIPTION
Jira: VI-88

Summary:
Pinned Prettier to version 3.5.3, updated local dependency installation to use npm ci --ignore-scripts, and configured pre-commit to use the locally installed Prettier.